### PR TITLE
Constraints checking between policies

### DIFF
--- a/src/include/scatteralloc/policy_malloc_constraints.hpp
+++ b/src/include/scatteralloc/policy_malloc_constraints.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "creationPolicies/Scatter.hpp"
+#include "distributionPolicies/XMallocSIMD.hpp"
+#include <boost/mpl/assert.hpp>
+
+namespace PolicyMalloc{
+
+  /** The default PolicyChecker (does always succeed)
+   */
+  template<typename Policy1, typename Policy2>
+  struct PolicyChecker{};
+
+
+  /** Enforces constraints on policies or combinations of polices
+   * 
+   * Uses template specialization of PolicyChecker
+   */
+  template < 
+     typename T_CreationPolicy, 
+     typename T_DistributionPolicy, 
+     typename T_OOMPolicy, 
+     typename T_GetHeapPolicy,
+     typename T_AlignmentPolicy
+       >
+  class PolicyConstraints{
+      PolicyChecker<T_CreationPolicy, T_DistributionPolicy> c;
+  };
+
+
+  /** Scatter and XMallocSIMD need the same pagesize!
+   *
+   * This constraint ensures that if the CreationPolicy "Scatter" and the
+   * DistributionPolicy "XMallocSIMD" are selected, they are configured to use
+   * the same value for their "pagesize"-parameter.
+   */
+  template<typename x, typename y, typename z >
+  struct PolicyChecker<
+    typename CreationPolicies::Scatter<x,y>,
+    typename DistributionPolicies::XMallocSIMD<z> 
+  >{
+    BOOST_MPL_ASSERT_MSG(x::pagesize::value == z::pagesize::value,
+        Pagesize_must_be_the_same_when_combining_Scatter_and_XMallocSIMD, () );
+  };
+
+}//namespace PolicyMalloc

--- a/src/include/scatteralloc/policy_malloc_hostclass.hpp
+++ b/src/include/scatteralloc/policy_malloc_hostclass.hpp
@@ -1,10 +1,10 @@
 #pragma once 
 
 #include "policy_malloc_utils.hpp"
+#include "policy_malloc_constraints.hpp"
 #include <boost/cstdint.hpp>
 #include <boost/tuple/tuple.hpp>
 #include <sstream>
-#include <typeinfo>
 
 namespace PolicyMalloc{
 
@@ -30,10 +30,13 @@ namespace PolicyMalloc{
       typedef T_AlignmentPolicy AlignmentPolicy;
       void* pool;
 
+      PolicyConstraints<CreationPolicy,DistributionPolicy,
+        OOMPolicy,ReservePoolPolicy,AlignmentPolicy> c;
 
     public:
+      typedef PolicyAllocator<CreationPolicy,DistributionPolicy,
+              OOMPolicy,ReservePoolPolicy,AlignmentPolicy> MyType;
 
-      typedef PolicyAllocator<CreationPolicy,DistributionPolicy,OOMPolicy,ReservePoolPolicy,AlignmentPolicy> MyType;
       __device__ void* alloc(size_t bytes){
         DistributionPolicy distributionPolicy;
 


### PR DESCRIPTION
- compile-time checks to ensure all policies are configured correctly
- currently: Scatter and XMallocSIMD need the same pagesize
- will allow to forbid certain combinations of policies alltogether
