### PR TITLE
Add easily reachable default properties

### DIFF
--- a/examples/policy_example01_config.hpp
+++ b/examples/policy_example01_config.hpp
@@ -16,8 +16,8 @@
     
 
 
-// configurate the CreationPolicy "Scatter"
-struct ScatterConfig{
+// configurate the CreationPolicy "Scatter" to modify the default behaviour
+struct ScatterHeapConfig : PolicyMalloc::CreationPolicies::Scatter<>::HeapProperties{
     typedef boost::mpl::int_<4096>  pagesize;
     typedef boost::mpl::int_<8>     accessblocks;
     typedef boost::mpl::int_<16>    regionsize;
@@ -25,7 +25,7 @@ struct ScatterConfig{
     typedef boost::mpl::bool_<false> resetfreedpages;
 };
 
-struct ScatterHashParams{
+struct ScatterHashConfig : PolicyMalloc::CreationPolicies::Scatter<>::HashingProperties{
     typedef boost::mpl::int_<38183> hashingK;
     typedef boost::mpl::int_<17497> hashingDistMP;
     typedef boost::mpl::int_<1>     hashingDistWP;
@@ -33,23 +33,23 @@ struct ScatterHashParams{
 };
 
 // configure the DistributionPolicy "XMallocSIMD"
-struct DistributionConfig{
-  typedef ScatterConfig::pagesize pagesize;
+struct XMallocConfig : PolicyMalloc::DistributionPolicies::XMallocSIMD<>::Properties {
+  typedef ScatterHeapConfig::pagesize pagesize;
 };
 
 // configure the AlignmentPolicy "Shrink"
-struct AlignmentConfig{
+struct ShrinkConfig : PolicyMalloc::AlignmentPolicies::Shrink<>::Properties {
   typedef boost::mpl::int_<16> dataAlignment;
 };
 
 // Define a new allocator and call it ScatterAllocator
 // which resembles the behaviour of ScatterAlloc
 typedef PolicyMalloc::PolicyAllocator< 
-  PolicyMalloc::CreationPolicies::Scatter<ScatterConfig,ScatterHashParams>,
-  PolicyMalloc::DistributionPolicies::XMallocSIMD<DistributionConfig>,
+  PolicyMalloc::CreationPolicies::Scatter<ScatterHeapConfig, ScatterHashConfig>,
+  PolicyMalloc::DistributionPolicies::XMallocSIMD<XMallocConfig>,
   PolicyMalloc::OOMPolicies::ReturnNull,
   PolicyMalloc::ReservePoolPolicies::SimpleCudaMalloc,
-  PolicyMalloc::AlignmentPolicies::Shrink<AlignmentConfig>
+  PolicyMalloc::AlignmentPolicies::Shrink<ShrinkConfig>
   > ScatterAllocator;
 
 // use "ScatterAllocator" as PolicyAllocator

--- a/src/include/scatteralloc/alignmentPolicies/Shrink_impl.hpp
+++ b/src/include/scatteralloc/alignmentPolicies/Shrink_impl.hpp
@@ -22,10 +22,13 @@ namespace Shrink2NS{
 
   template<typename T_Config>
   class Shrink{
+    public:
+    typedef T_Config Properties;
+
+    private:
     typedef boost::uint32_t uint32;
     typedef Shrink2NS::__PointerEquivalent<sizeof(char*)>::type PointerEquivalent;
 
-    typedef T_Config Properties;
 
 #ifdef POLICYMALLOC_AP_SHRINK_DATAALIGNMENT
     static const uint32 dataAlignment = POLICYMALLOC_AP_SHRINK_DATAALIGNMENT;

--- a/src/include/scatteralloc/creationPolicies/Scatter_impl.hpp
+++ b/src/include/scatteralloc/creationPolicies/Scatter_impl.hpp
@@ -22,34 +22,37 @@ namespace CreationPolicies{
   class Scatter
   {
 
+    public:
+      typedef T_Config  HeapProperties;
+      typedef T_Hashing HashingProperties;
+      struct  Properties : HeapProperties, HashingProperties{};
+      
     private:
       typedef boost::uint32_t uint32;
-      typedef T_Config Properties;
-      typedef T_Hashing HashParams;
 
 
 #ifndef POLICYMALLOC_CP_SCATTER_PAGESIZE
-#define POLICYMALLOC_CP_SCATTER_PAGESIZE  static_cast<uint32>(Properties::pagesize::value)
+#define POLICYMALLOC_CP_SCATTER_PAGESIZE  static_cast<uint32>(HeapProperties::pagesize::value)
 #endif
       static const uint32 pagesize      = POLICYMALLOC_CP_SCATTER_PAGESIZE;
 
 #ifndef POLICYMALLOC_CP_SCATTER_ACCESSBLOCKS
-#define POLICYMALLOC_CP_SCATTER_ACCESSBLOCKS static_cast<uint32>(Properties::accessblocks::value)
+#define POLICYMALLOC_CP_SCATTER_ACCESSBLOCKS static_cast<uint32>(HeapProperties::accessblocks::value)
 #endif
       static const uint32 accessblocks  = POLICYMALLOC_CP_SCATTER_ACCESSBLOCKS;
 
 #ifndef POLICYMALLOC_CP_SCATTER_REGIONSIZE
-#define POLICYMALLOC_CP_SCATTER_REGIONSIZE static_cast<uint32>(Properties::regionsize::value)
+#define POLICYMALLOC_CP_SCATTER_REGIONSIZE static_cast<uint32>(HeapProperties::regionsize::value)
 #endif
       static const uint32 regionsize    = POLICYMALLOC_CP_SCATTER_REGIONSIZE;
 
 #ifndef POLICYMALLOC_CP_SCATTER_WASTEFACTOR
-#define POLICYMALLOC_CP_SCATTER_WASTEFACTOR static_cast<uint32>(Properties::wastefactor::value)
+#define POLICYMALLOC_CP_SCATTER_WASTEFACTOR static_cast<uint32>(HeapProperties::wastefactor::value)
 #endif
       static const uint32 wastefactor   = POLICYMALLOC_CP_SCATTER_WASTEFACTOR;
 
 #ifndef POLICYMALLOC_CP_SCATTER_RESETFREEDPAGES
-#define POLICYMALLOC_CP_SCATTER_RESETFREEDPAGES static_cast<bool>(Properties::resetfreedpages::value)
+#define POLICYMALLOC_CP_SCATTER_RESETFREEDPAGES static_cast<bool>(HeapProperties::resetfreedpages::value)
 #endif
       static const bool resetfreedpages = POLICYMALLOC_CP_SCATTER_RESETFREEDPAGES;
 
@@ -70,22 +73,22 @@ namespace CreationPolicies{
       static const uint32 HierarchyThreshold =  (pagesize - 2*sizeof(uint32))/33;
 
 #ifndef POLICYMALLOC_CP_SCATTER_HASHINGK
-#define POLICYMALLOC_CP_SCATTER_HASHINGK    static_cast<uint32>(HashParams::hashingK::value)
+#define POLICYMALLOC_CP_SCATTER_HASHINGK    static_cast<uint32>(HashingProperties::hashingK::value)
 #endif
      static const uint32 hashingK       = POLICYMALLOC_CP_SCATTER_HASHINGK;
 
 #ifndef POLICYMALLOC_CP_SCATTER_HASHINGDISTMP
-#define POLICYMALLOC_CP_SCATTER_HASHINGDISTMP static_cast<uint32>(HashParams::hashingDistMP::value)
+#define POLICYMALLOC_CP_SCATTER_HASHINGDISTMP static_cast<uint32>(HashingProperties::hashingDistMP::value)
 #endif
      static const uint32 hashingDistMP  = POLICYMALLOC_CP_SCATTER_HASHINGDISTMP;
 
 #ifndef POLICYMALLOC_CP_SCATTER_HASHINGDISTWP
-#define POLICYMALLOC_CP_SCATTER_HASHINGDISTWP static_cast<uint32>(HashParams::hashingDistWP::value)
+#define POLICYMALLOC_CP_SCATTER_HASHINGDISTWP static_cast<uint32>(HashingProperties::hashingDistWP::value)
 #endif
      static const uint32 hashingDistWP  = POLICYMALLOC_CP_SCATTER_HASHINGDISTWP;
 
 #ifndef POLICYMALLOC_CP_SCATTER_HASHINGDISTWPREL
-#define POLICYMALLOC_CP_SCATTER_HASHINGDISTWPREL static_cast<uint32>(HashParams::hashingDistWPRel::value)
+#define POLICYMALLOC_CP_SCATTER_HASHINGDISTWPREL static_cast<uint32>(HashingProperties::hashingDistWPRel::value)
 #endif
      static const uint32 hashingDistWPRel = POLICYMALLOC_CP_SCATTER_HASHINGDISTWPREL;
 
@@ -685,7 +688,7 @@ namespace CreationPolicies{
         SCATTERALLOC_CUDA_CHECKED_CALL(cudaGetSymbolAddress((void**)&heap,obj));
         ScatterKernelDetail::initKernel<<<1,256>>>(heap, pool, memsize);
         return heap;
-      }   
+      }
 
 
       template < typename T_Obj>

--- a/src/include/scatteralloc/distributionPolicies/XMallocSIMD_impl.hpp
+++ b/src/include/scatteralloc/distributionPolicies/XMallocSIMD_impl.hpp
@@ -23,8 +23,10 @@ namespace DistributionPolicies{
       uint32 myoffset;
       uint32 threadcount;
       uint32 req_size;
+    public:
       typedef T_Config Properties;
 
+    private:
 #ifndef POLICYMALLOC_DP_XMALLOCSIMD_PAGESIZE
 #define POLICYMALLOC_DP_XMALLOCSIMD_PAGESIZE Properties::pagesize::value
 #endif


### PR DESCRIPTION
- Each policy ships with at least a "Properties" typedef that can be used for inheritance/overriding.
- Scatter has also a more fine-grained split available
