### PR TITLE
Fix Broken Links Due to Renaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Change Log / Release Log for ScatterAlloc
 
 This is our first bug fix release.
 We closed all issues documented in
-[Milestone *Bug fixes*](https://github.com/ComputationalRadiationPhysics/scatteralloc/issues?milestone=1&state=closed)
+[Milestone *Bug fixes*](https://github.com/ComputationalRadiationPhysics/mallocMC/issues?milestone=1&state=closed)
 
 ### Changes to 1.0.1
 

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ Branches
 
 | *branch*    | *state* | *description*           |
 | ----------- | ------- | ----------------------- |
-| **master**  | [![Build Status Master](https://travis-ci.org/ComputationalRadiationPhysics/scatteralloc.png?branch=master)](https://travis-ci.org/ComputationalRadiationPhysics/scatteralloc "master") | our stable new releases |
-| **dev**     | [![Build Status Development](https://travis-ci.org/ComputationalRadiationPhysics/scatteralloc.png?branch=dev)](https://travis-ci.org/ComputationalRadiationPhysics/scatteralloc "dev") | our development branch - start and merge new branches here |
+| **master**  | [![Build Status Master](https://travis-ci.org/ComputationalRadiationPhysics/mallocMC.png?branch=master)](https://travis-ci.org/ComputationalRadiationPhysics/mallocMC "master") | our stable new releases |
+| **dev**     | [![Build Status Development](https://travis-ci.org/ComputationalRadiationPhysics/mallocMC.png?branch=dev)](https://travis-ci.org/ComputationalRadiationPhysics/mallocMC "dev") | our development branch - start and merge new branches here |
 | **tugraz**  | n/a | kind-of the "upstream" branch - only used to receive new releases from the TU Graz group |
 
 


### PR DESCRIPTION
Fixes the broken links. Some re-links to the base project crp/scatteralloc are fine.
