### PR TITLE
Regions are now correctly initialized

### DIFF
--- a/src/include/mallocMC/creationPolicies/Scatter_impl.hpp
+++ b/src/include/mallocMC/creationPolicies/Scatter_impl.hpp
@@ -718,7 +718,7 @@ namespace ScatterKernelDetail{
           ptes[i].init();
           page[i].init();
         }
-        for(uint32 i = linid; i < numregions; i+= numregions)
+        for(uint32 i = linid; i < numregions; i+= threads)
           regions[i] = 0;
 
         if(linid == 0)


### PR DESCRIPTION
- previously, not all the regions were initialized (if there were more regions than threads*blocks)
