### PR TITLE
Bugfix: counter could get too high (racecondition)

### DIFF
--- a/src/include/mallocMC/creationPolicies/Scatter_impl.hpp
+++ b/src/include/mallocMC/creationPolicies/Scatter_impl.hpp
@@ -320,7 +320,7 @@ namespace ScatterKernelDetail{
       __device__ inline void* tryUsePage(uint32 page, uint32 chunksize)
       {
 
-        void* chunk_ptr = NULL
+        void* chunk_ptr = NULL;
 
         //increse the fill level
         uint32 filllevel = atomicAdd((uint32*)&(_ptes[page].count), 1);


### PR DESCRIPTION
How the bug worked:
- addChunkHierarchy could return 0 in some rare conditions
- in these cases, tryUsePage did not decrease the counter again
