### PR TITLE
Bugfix: bitmask in PTE wrong (racecondition)

### DIFF
--- a/src/include/mallocMC/creationPolicies/Scatter_impl.hpp
+++ b/src/include/mallocMC/creationPolicies/Scatter_impl.hpp
@@ -444,9 +444,8 @@ namespace ScatterKernelDetail{
           uint32* onpagemasks = (uint32*)(_page[page].data + chunksize*(fullsegments*32 + additional_chunks));
           uint32 old = atomicAnd(onpagemasks + segment, ~(1 << withinsegment));
 
-          uint32 elementsinsegment = segment < fullsegments ? 32 : additional_chunks;
-          if(__popc(old) == elementsinsegment)
-            atomicAnd((uint32*)&_ptes[page].bitmask, ~(1 << segment));
+          // always do this, since it might fail due to a race-condition with addChunkHierarchy
+          atomicAnd((uint32*)&_ptes[page].bitmask, ~(1 << segment));
         }
         else
         {


### PR DESCRIPTION
idea of how the bug worked (in hierarchical pages):
- currently selected onpagemask is not full.
- thread starts searching for free slot
- new free slots appear where the thread already searched, while the free slots in unvisited places disappear
- thread does not find a free slot, sets `_ptes[page].bitmask` at position of the onpagemask to 1, indicating that the onpagemask/segment is completely filled.
- since `_ptes[page].bitmask` indicates, that the onpagemask/segment is completely filled, no other threads will ever enter this segment.
- The bug hits, since the  `_ptes[page].bitmask` on position onpagemask is only set to 0 by a thread that had a completely filled onpagemask and removes 1 element. Since the onpagemask was never completely filled, no thread will perform the reset
- memory is lost.
