### PR TITLE
fixed 2 warnings with -Wsign-compare

### DIFF
--- a/src/include/mallocMC/alignmentPolicies/Shrink_impl.hpp
+++ b/src/include/mallocMC/alignmentPolicies/Shrink_impl.hpp
@@ -74,7 +74,7 @@ namespace Shrink2NS{
 #endif
     static const uint32 dataAlignment = MALLOCMC_AP_SHRINK_DATAALIGNMENT;
 
-    BOOST_STATIC_ASSERT(dataAlignment > 0); 
+    BOOST_STATIC_ASSERT(static_cast<uint32>(dataAlignment) > 0);
     //dataAlignment must also be a power of 2!
     BOOST_STATIC_ASSERT(dataAlignment && !(dataAlignment & (dataAlignment-1)) ); 
 

--- a/src/include/mallocMC/distributionPolicies/XMallocSIMD_impl.hpp
+++ b/src/include/mallocMC/distributionPolicies/XMallocSIMD_impl.hpp
@@ -77,7 +77,7 @@ namespace DistributionPolicies{
 
       //all the properties must be unsigned integers > 0
       BOOST_STATIC_ASSERT(!std::numeric_limits<typename Properties::pagesize::type>::is_signed);
-      BOOST_STATIC_ASSERT(pagesize > 0);
+      BOOST_STATIC_ASSERT(static_cast<uint32>(pagesize) > 0);
 
     public:
       static const uint32 _pagesize = pagesize;


### PR DESCRIPTION
Interestingly, changing the line to something like

``` c++
BOOST_STATIC_ASSERT(dataAlignment > 0U);
```

``` c++
BOOST_STATIC_ASSERT(dataAlignment > (uint32)0);
```

``` c++
BOOST_STATIC_ASSERT(dataAlignment > static_cast<unsigned>(0));
```

did **not** work :confused:
