### PR TITLE
Bugfix: free did not work  when using coalescing

### DIFF
--- a/src/include/mallocMC/distributionPolicies/XMallocSIMD_impl.hpp
+++ b/src/include/mallocMC/distributionPolicies/XMallocSIMD_impl.hpp
@@ -97,7 +97,7 @@ namespace DistributionPolicies{
         //second half: make sure that all coalesced allocations can fit within one page
         //necessary for offset calculation
         bool coalescible = bytes > 0 && bytes < (pagesize / 32);
-        uint32 threadcount = __popc(__ballot(coalescible));
+        threadcount = __popc(__ballot(coalescible));
 
         if (coalescible && threadcount > 1)
         {


### PR DESCRIPTION
- local variable "threadcount" did shadow a class member
- better syntax highlighting in my VIM would have made this more
  obvious :(
- `-Wshadow` would have warned about it :(
