### PR TITLE
Interface changed for OOMPolicy

### DIFF
--- a/src/include/mallocMC/creationPolicies/OldMalloc_impl.hpp
+++ b/src/include/mallocMC/creationPolicies/OldMalloc_impl.hpp
@@ -52,8 +52,8 @@ namespace CreationPolicies{
       free(mem);
     }
 
-    __device__ bool isOOM(void* p){
-      return  32 == __popc(__ballot(p == NULL));
+    __device__ bool isOOM(void* p, size_t s){
+      return s && (p == NULL);
     }
 
     template < typename T>

--- a/src/include/mallocMC/creationPolicies/Scatter_impl.hpp
+++ b/src/include/mallocMC/creationPolicies/Scatter_impl.hpp
@@ -781,9 +781,9 @@ namespace ScatterKernelDetail{
         }
       }
 
-      __device__ bool isOOM(void* p){
-        // all threads in a warp return get NULL
-        return  32 == __popc(__ballot(p == NULL));
+      __device__ bool isOOM(void* p, size_t s){
+        // one thread that requested memory returned null
+        return  s && (p == NULL);
       }
 
 

--- a/src/include/mallocMC/mallocMC_hostclass.hpp
+++ b/src/include/mallocMC/mallocMC_hostclass.hpp
@@ -112,7 +112,7 @@ namespace mallocMC{
         bytes            = AlignmentPolicy::applyPadding(bytes);
         uint32 req_size  = distributionPolicy.collect(bytes);
         void* memBlock   = CreationPolicy::create(req_size);
-        const bool oom   = CreationPolicy::isOOM(memBlock);
+        const bool oom   = CreationPolicy::isOOM(memBlock, req_size);
         if(oom) memBlock = OOMPolicy::handleOOM(memBlock);
         void* myPart     = distributionPolicy.distribute(memBlock);
 


### PR DESCRIPTION
In case of non-coalesced requests, it could happen that one thread did not get memory while the others did. This was not recognized by the policy until now.
Old behavior: OOM is defined as the state where no participating thread in the warp got any memory (this did work for coalesced access and non-coalesced cases where the whole warp behaves the same).

New behavior: OOM is defined as the state where a thread actually tried to get memory (size != 0), but did get NULL from the allocator. This should always work.
