### PR TITLE
Fix for the onPageTables formula

### DIFF
--- a/src/include/mallocMC/creationPolicies/Scatter_impl.hpp
+++ b/src/include/mallocMC/creationPolicies/Scatter_impl.hpp
@@ -187,15 +187,11 @@ namespace ScatterKernelDetail{
          * bit fields when the page is used for a small chunk size
          * @param previous_chunksize the chunksize which was uses for the page before
          */
-        __device__ void init(uint32 previous_chunksize = 0)
+        __device__ void init()
         {
-          //TODO: we can speed this up for pages being freed, because we know the
-          //chunksize used before (these bits must be zero again) 
-
-          //init the entire data which can hold bitfields 
-          uint32 max_bits = min(32*32,pagesize/minChunkSize1);
-          uint32 max_entries = divup<uint32>(max_bits/8,sizeof(uint32))*sizeof(uint32);
-          uint32* write = (uint32*)(data+(pagesize-max_entries));
+          //clear the entire data which can hold bitfields
+          uint32 first_possible_metadata = 32*HierarchyThreshold;
+          uint32* write = (uint32*)(data+(pagesize-first_possible_metadata));
           while(write < (uint32*)(data + pagesize))
             *write++ = 0;
         }


### PR DESCRIPTION
- relies on HierarchyThreshold to find a good place to start the
  cleanup
- validity of the formula was tested for ALL pagesizes ranging from 16
  byte to 32 Mbyte with ALL possible chunkSizes that result in a
  hierarchical page layout for the given pagesize.
- Code that was used for validity testing can be found in  https://github.com/slizzered/mallocMC/commit/72614073f3fc882c32c7f13ac2fc205be316cefb
- Code that demonstrated the bug in the first place: https://github.com/slizzered/mallocMC/commit/47f1754ba41e4cc5d876338499b201fbefefff7b
- the previous comment in the code mentioned, that it might be possible to free
  only those areas that were used as metadata based on the previous
  chunkSize. This does NOT work: if the new metadata includes some
  parts that were previously used as payload-data, this parts will
  still be non-zero and the bug will occur again.
- closes #70
