### PR TITLE
HIP: get warpsize from define

### DIFF
--- a/src/include/mallocMC/mallocMC_utils.hpp
+++ b/src/include/mallocMC/mallocMC_utils.hpp
@@ -72,7 +72,14 @@ namespace mallocMC
 #if defined(__CUDA_ARCH__)
     constexpr auto warpSize = 32; // TODO
 #elif(MALLOCMC_DEVICE_COMPILE && BOOST_COMP_HIP)
+// defined: https://github.com/llvm/llvm-project/blob/62ec4ac90738a5f2d209ed28c822223e58aaaeb7/clang/lib/Basic/Targets/AMDGPU.cpp#L400
+// overview wave front size: https://github.com/llvm/llvm-project/blob/efc063b621ea0c4d1e452bcade62f7fc7e1cc937/clang/test/Driver/amdgpu-macros.cl#L70-L115
+// gfx10XX has 32 threads per wavefront else 64
+#   if(HIP_VERSION_MAJOR >= 4)
+    constexpr auto warpSize = __AMDGCN_WAVEFRONT_SIZE;
+#   else
     constexpr auto warpSize = 64;
+#   endif
 #else
     constexpr auto warpSize = 1;
 #endif


### PR DESCRIPTION
For HIP 4.0+ use `__AMDGCN_WAVEFRONT_SIZE` to get the warp size.