### PR TITLE
update changelog for 2.5.0crp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,33 @@
 Change Log / Release Log for mallocMC
 ================================================================
 
+2.5.0crp
+--------
+**Date:** 2021-02-18
+
+This release removes the native usage of CUDA by alpaka.
+Attention: This release depends on an unreleased [alpaka 0.5.0dev](https://github.com/alpaka-group/alpaka/commit/34870a73ecf702069465aa030fbdf301c4d22c61) 
+version before the heavy alpaka namespace refactoring.
+
+### Changes to mallocMC 2.4.0crp
+
+**Features**
+- Port to alpaka #173
+
+**Bug fixes**
+- fix HIP support (warpsize, activemask, compile issues) #182
+- fix data race and printf issue #189
+- fix data races in `Scatter.hpp` #190
+- fix clang cuda compile #192
+
+**Misc:**
+- Added alpaka subtree and switched to C++14 #176
+- Added 3rd party catch.hpp and made CMake find it #179
+- Update documentation after switch to alpaka #194
+- Update .clang-format and apply clang-format #197
+
+Thanks to Bernhard Manfred Gruber and Rene Widera for contributing to this release!
+
 2.4.0crp
 --------
 **Date:** 2020-05-28


### PR DESCRIPTION
Update changelog.

This PR is against the release branch.

The release is based on a not published alpaka version. The idea is to keep a snapshot that depends on a version before the huge namespace alpaka refactorings and helps projects to migrate to newer mallocMC versions.