### PR TITLE
add full support for CPU accelerators

### DIFF
--- a/examples/mallocMC_example01.cpp
+++ b/examples/mallocMC_example01.cpp
@@ -26,16 +26,19 @@
   THE SOFTWARE.
 */
 
+#include <algorithm>
 #include <alpaka/alpaka.hpp>
+#include <alpaka/example/ExampleDefaultAcc.hpp>
+#include <cassert>
 #include <iostream>
 #include <mallocMC/mallocMC.hpp>
 #include <numeric>
 
 using Dim = alpaka::DimInt<1>;
 using Idx = std::size_t;
-// using Acc = alpaka::AccCpuThreads<Dim, Idx>;
-// using Acc = alpaka::AccCpuOmp2Threads<Dim, Idx>;
-using Acc = alpaka::AccGpuCudaRt<Dim, Idx>;
+
+// Define the device accelerator
+using Acc = alpaka::ExampleDefaultAcc<Dim, Idx>;
 
 struct ScatterHeapConfig
 {
@@ -67,7 +70,7 @@ struct ShrinkConfig
 using ScatterAllocator = mallocMC::Allocator<
     Acc,
     mallocMC::CreationPolicies::Scatter<ScatterHeapConfig, ScatterHashConfig>,
-    mallocMC::DistributionPolicies::XMallocSIMD<XMallocConfig>,
+    mallocMC::DistributionPolicies::Noop,
     mallocMC::OOMPolicies::ReturnNull,
     mallocMC::ReservePoolPolicies::AlpakaBuf<Acc>,
     mallocMC::AlignmentPolicies::Shrink<ShrinkConfig>>;
@@ -78,13 +81,17 @@ ALPAKA_STATIC_ACC_MEM_GLOBAL int** arC;
 
 auto main() -> int
 {
-    constexpr auto block = 32;
-    constexpr auto grid = 32;
     constexpr auto length = 100;
-    static_assert(length <= block * grid, ""); // necessary for used algorithm
 
     const auto dev = alpaka::getDevByIdx<Acc>(0);
     auto queue = alpaka::Queue<Acc, alpaka::Blocking>{dev};
+
+    auto const devProps = alpaka::getAccDevProps<Acc>(dev);
+    unsigned const block = std::min(static_cast<size_t>(32u), static_cast<size_t>(devProps.m_blockThreadCountMax));
+
+    // round up
+    auto grid = (length + block - 1u) / block;
+    assert(length <= block * grid); // necessary for used algorithm
 
     // init the heap
     std::cerr << "initHeap...";

--- a/examples/mallocMC_example03.cpp
+++ b/examples/mallocMC_example03.cpp
@@ -26,7 +26,9 @@
   THE SOFTWARE.
 */
 
+#include <algorithm>
 #include <alpaka/alpaka.hpp>
+#include <alpaka/example/ExampleDefaultAcc.hpp>
 #include <cassert>
 #include <iostream>
 #include <mallocMC/mallocMC.hpp>
@@ -35,9 +37,9 @@
 
 using Dim = alpaka::DimInt<1>;
 using Idx = std::size_t;
-// using Acc = alpaka::AccCpuThreads<Dim, Idx>;
-// using Acc = alpaka::AccCpuOmp2Threads<Dim, Idx>;
-using Acc = alpaka::AccGpuCudaRt<Dim, Idx>;
+
+// Define the device accelerator
+using Acc = alpaka::ExampleDefaultAcc<Dim, Idx>;
 
 struct ScatterConfig
 {
@@ -100,10 +102,12 @@ auto main() -> int
 {
     const auto dev = alpaka::getDevByIdx<Acc>(0);
     auto queue = alpaka::Queue<Acc, alpaka::Blocking>{dev};
+    auto const devProps = alpaka::getAccDevProps<Acc>(dev);
+    unsigned const block = std::min(static_cast<size_t>(32u), static_cast<size_t>(devProps.m_blockThreadCountMax));
 
     ScatterAllocator scatterAlloc(dev, queue, 1U * 1024U * 1024U * 1024U); // 1GB for device-side malloc
 
-    const auto workDiv = alpaka::WorkDivMembers<Dim, Idx>{Idx{1}, Idx{32}, Idx{1}};
+    const auto workDiv = alpaka::WorkDivMembers<Dim, Idx>{Idx{1}, Idx{block}, Idx{1}};
     alpaka::enqueue(queue, alpaka::createTaskKernel<Acc>(workDiv, ExampleKernel{}, scatterAlloc.getAllocatorHandle()));
 
     std::cout << "Slots from Host: " << scatterAlloc.getAvailableSlots(dev, queue, 1) << '\n';

--- a/src/include/mallocMC/creationPolicies/Scatter.hpp
+++ b/src/include/mallocMC/creationPolicies/Scatter.hpp
@@ -36,6 +36,7 @@
 #include "../mallocMC_utils.hpp"
 #include "Scatter.hpp"
 
+#include <algorithm>
 #include <alpaka/alpaka.hpp>
 #include <atomic>
 #include <cassert>
@@ -929,7 +930,11 @@ namespace mallocMC
                 using VecType = alpaka::Vec<Dim, Idx>;
 
                 auto threadsPerBlock = VecType::ones();
-                threadsPerBlock[Dim::value - 1] = 256u;
+
+                auto const devProps = alpaka::getAccDevProps<AlpakaAcc>(dev);
+
+                threadsPerBlock[Dim::value - 1]
+                    = std::min(static_cast<size_t>(256u), static_cast<size_t>(devProps.m_blockThreadCountMax));
 
                 const auto workDiv = alpaka::WorkDivMembers<Dim, Idx>{
                     VecType::ones(),
@@ -1106,7 +1111,11 @@ namespace mallocMC
                 auto numBlocks = VecType::ones();
                 numBlocks[Dim::value - 1] = 64u;
                 auto threadsPerBlock = VecType::ones();
-                threadsPerBlock[Dim::value - 1] = 256u;
+
+                auto const devProps = alpaka::getAccDevProps<AlpakaAcc>(dev);
+
+                threadsPerBlock[Dim::value - 1]
+                    = std::min(static_cast<size_t>(256u), static_cast<size_t>(devProps.m_blockThreadCountMax));
 
                 const auto workDiv = alpaka::WorkDivMembers<Dim, Idx>{
                     numBlocks,

--- a/tests/dimensions.cpp
+++ b/tests/dimensions.cpp
@@ -70,7 +70,7 @@ void test1D()
         Acc,
         mallocMC::CreationPolicies::Scatter<ScatterConfig, ScatterHashParams>,
         // mallocMC::CreationPolicies::OldMalloc,
-        mallocMC::DistributionPolicies::XMallocSIMD<DistributionConfig>,
+        mallocMC::DistributionPolicies::Noop,
         mallocMC::OOMPolicies::ReturnNull,
         mallocMC::ReservePoolPolicies::AlpakaBuf<Acc>,
         // mallocMC::ReservePoolPolicies::CudaSetLimits,
@@ -306,6 +306,7 @@ void test3D()
             scatterAlloc.getAllocatorHandle()));
 }
 
+#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
 TEST_CASE("1D AccGpuCudaRt")
 {
     test1D<alpaka::AccGpuCudaRt>();
@@ -320,7 +321,26 @@ TEST_CASE("3D AccGpuCudaRt")
 {
     test3D<alpaka::AccGpuCudaRt>();
 }
+#endif
 
+#if defined(ALPAKA_ACC_GPU_HIP_ENABLED)
+TEST_CASE("1D AccGpuHipRt")
+{
+    test1D<alpaka::AccGpuHipRt>();
+}
+
+TEST_CASE("2D AccGpuHipRt")
+{
+    test2D<alpaka::AccGpuHipRt>();
+}
+
+TEST_CASE("3D AccGpuHipRt")
+{
+    test3D<alpaka::AccGpuHipRt>();
+}
+#endif
+
+#if defined(ALPAKA_ACC_CPU_B_SEQ_T_THREADS_ENABLED)
 TEST_CASE("1D AccCpuThreads")
 {
     test1D<alpaka::AccCpuThreads>();
@@ -335,7 +355,9 @@ TEST_CASE("3D AccCpuThreads")
 {
     test3D<alpaka::AccCpuThreads>();
 }
+#endif
 
+#if defined(ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLED)
 TEST_CASE("1D AccCpuOmp2Threads")
 {
     test1D<alpaka::AccCpuOmp2Threads>();
@@ -350,3 +372,38 @@ TEST_CASE("3D AccCpuOmp2Threads")
 {
     test3D<alpaka::AccCpuOmp2Threads>();
 }
+#endif
+
+#if defined(ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED)
+TEST_CASE("1D AccCpuOmp2Blocks")
+{
+    test1D<alpaka::AccCpuOmp2Blocks>();
+}
+
+TEST_CASE("2D AccCpuOmp2Blocks")
+{
+    test2D<alpaka::AccCpuOmp2Blocks>();
+}
+
+TEST_CASE("3D AccCpuOmp2Blocks")
+{
+    test3D<alpaka::AccCpuOmp2Blocks>();
+}
+#endif
+
+#if defined(ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED)
+TEST_CASE("1D AccCpuSerial")
+{
+    test1D<alpaka::AccCpuSerial>();
+}
+
+TEST_CASE("2D AccCpuSerial")
+{
+    test2D<alpaka::AccCpuSerial>();
+}
+
+TEST_CASE("3D AccCpuSerial")
+{
+    test3D<alpaka::AccCpuSerial>();
+}
+#endif

--- a/tests/verify_heap.cpp
+++ b/tests/verify_heap.cpp
@@ -32,6 +32,7 @@ constexpr auto ELEMS_PER_SLOT = 750;
 
 #include "verify_heap_config.hpp"
 
+#include <algorithm>
 #include <alpaka/alpaka.hpp>
 #include <cstdio>
 #include <iostream>
@@ -49,7 +50,7 @@ bool verbose = false;
 // the type of the elements to allocate
 using allocElem_t = unsigned long long;
 
-auto run_heap_verification(const size_t, const unsigned, const unsigned, const bool) -> bool;
+auto run_heap_verification(const size_t, const unsigned, unsigned, const bool) -> bool;
 void parse_cmdline(const int, char**, size_t*, unsigned*, unsigned*, bool*);
 void print_help(char**);
 
@@ -611,14 +612,14 @@ void print_machine_readable(
  * @return true if the verification was successful,
  *         false otherwise
  */
-auto run_heap_verification(
-    const size_t heapMB,
-    const unsigned blocks,
-    const unsigned threads,
-    const bool machine_readable) -> bool
+auto run_heap_verification(const size_t heapMB, const unsigned blocks, unsigned threads, const bool machine_readable)
+    -> bool
 {
     const auto dev = alpaka::getDevByIdx<Acc>(0);
     auto queue = Queue{dev};
+
+    auto const devProps = alpaka::getAccDevProps<Acc>(dev);
+    threads = std::min(static_cast<size_t>(threads), static_cast<size_t>(devProps.m_blockThreadCountMax));
 
     const size_t heapSize = size_t(1024U * 1024U) * heapMB;
     const size_t slotSize = sizeof(allocElem_t) * ELEMS_PER_SLOT;

--- a/tests/verify_heap_config.hpp
+++ b/tests/verify_heap_config.hpp
@@ -29,13 +29,14 @@
 #pragma once
 
 #include <alpaka/alpaka.hpp>
+#include <alpaka/example/ExampleDefaultAcc.hpp>
 #include <mallocMC/mallocMC.hpp>
 
 using Dim = alpaka::DimInt<1>;
 using Idx = std::size_t;
-// using Acc = alpaka::AccCpuThreads<Dim, Idx>;
-// using Acc = alpaka::AccCpuOmp2Threads<Dim, Idx>;
-using Acc = alpaka::AccGpuCudaRt<Dim, Idx>;
+
+// Define the device accelerator
+using Acc = alpaka::ExampleDefaultAcc<Dim, Idx>;
 
 // configurate the CreationPolicy "Scatter"
 struct ScatterConfig
@@ -72,7 +73,7 @@ struct AlignmentConfig
 using ScatterAllocator = mallocMC::Allocator<
     Acc,
     mallocMC::CreationPolicies::Scatter<ScatterConfig, ScatterHashParams>,
-    mallocMC::DistributionPolicies::XMallocSIMD<DistributionConfig>,
+    mallocMC::DistributionPolicies::Noop,
     mallocMC::OOMPolicies::ReturnNull,
     mallocMC::ReservePoolPolicies::AlpakaBuf<Acc>,
     mallocMC::AlignmentPolicies::Shrink<AlignmentConfig>>;


### PR DESCRIPTION
Until now we supported only alpaka accelerators which can be used with
multiple threads per block.

- add support for more accelerators in the example (except TBB and BoostFiber)
- remove usage of the distribution policy `XMallocSIMD` because of #212 (this will be reverted after the issue if fixed)