### PR TITLE
fix scatter allocation

### DIFF
--- a/src/include/mallocMC/creationPolicies/Scatter.hpp
+++ b/src/include/mallocMC/creationPolicies/Scatter.hpp
@@ -767,10 +767,13 @@ namespace mallocMC
             {
                 if(bytes == 0)
                     return 0;
-                // take care of padding
-                // bytes = (bytes + dataAlignment - 1) & ~(dataAlignment-1); //
-                // in alignment-policy
-                if(bytes < pagesize)
+                /* Take care of padding
+                 * bytes = (bytes + dataAlignment - 1) & ~(dataAlignment-1);
+                 * in alignment-policy.
+                 * bytes == pagesize must be handled by allocChunked() else maxchunksize calculation based
+                 * on the waste factor is colliding with the allocation schema in allocPageBased().
+                 */
+                if(bytes <= pagesize)
                     // chunck based
                     return allocChunked(acc, bytes);
                 else


### PR DESCRIPTION
In case pagesize bytes will be allocated and within `allocChunked` an
allocation is increased based on the waste factor to fit into a chunk
with the size of a page the locking is not working because `allocPageBased`
locking is not compatible to the locking mechanism used in
`allocChunked`.