### PR TITLE
fix data races

### DIFF
--- a/src/include/mallocMC/creationPolicies/Scatter.hpp
+++ b/src/include/mallocMC/creationPolicies/Scatter.hpp
@@ -415,7 +415,7 @@ namespace mallocMC
                 const uint32 filllevel = alpaka::atomicOp<alpaka::AtomicAdd>(acc, (uint32*) &(_ptes[page].count), 1u);
 
                 // if resetfreedpages == false we do not need to re-check filllevel or chunksize
-                bool tryAllocMem = resetfreedpages ? false : true;
+                bool tryAllocMem = !resetfreedpages;
 
                 // if _ptes[page].count >= pagesize then page is currently freed by another thread
                 if(resetfreedpages && filllevel < pagesize)


### PR DESCRIPTION
- reset `chunksize` in `deallocChunked()` via `atomicCas` to ensure that the write is not colliding with value changes in `allocChunked()`.
- `allocChunked()` update region fill level via `atomicCas` to avoid that the reset of the fill level in `deallocChunked` is overwritten.
- `deallocChunked()` reset the fill level via an `atomicExch` to avoid that the value update in `allocChunked()` is missing the update.