### PR TITLE
fix `calcAdditionalChunks`

### DIFF
--- a/src/include/mallocMC/creationPolicies/Scatter.hpp
+++ b/src/include/mallocMC/creationPolicies/Scatter.hpp
@@ -330,11 +330,14 @@ namespace mallocMC
                 uint32 chunksize) -> uint32
             {
                 if(fullsegments != 32)
-                    return alpaka::math::max(
-                               acc,
-                               0u,
-                               (int) pagesize - (int) fullsegments * segmentsize - (int) sizeof(uint32))
-                        / chunksize;
+                    return alpaka::math::min(
+                        acc,
+                        31,
+                        alpaka::math::max(
+                            acc,
+                            0,
+                            (int) pagesize - (int) fullsegments * segmentsize - (int) sizeof(uint32))
+                            / chunksize);
                 else
                     return 0;
             }


### PR DESCRIPTION
Additional chunks can not be more than 31. In case the page is large and the allocation small the current implementation could return wrong results larger 31.