### PR TITLE
Add alignment to minChunkSize in ScatterAlloc

### DIFF
--- a/src/include/mallocMC/creationPolicies/Scatter.hpp
+++ b/src/include/mallocMC/creationPolicies/Scatter.hpp
@@ -175,7 +175,11 @@ namespace mallocMC
              * existing chunk.
              * Each page can have 32x32 chunks. To maintain 32 chunks we need 32 bitmask on the page (each 32bit)
              */
-            static constexpr uint32 minChunkSize = (pagesize - 32u * sizeof(uint32)) / (32u * 32u);
+            static constexpr uint32 minChunkSizeUnaligned = (pagesize - 32u * sizeof(uint32)) / (32u * 32u);
+            // Set minChunkSize to largest multiple of minChunkSizeAlignment that is <= minChunkSizeUnaligned
+            static constexpr uint32 minChunkSizeAlignment = 16u;
+            static constexpr uint32 minChunkSize
+                = (minChunkSizeUnaligned / minChunkSizeAlignment) * minChunkSizeAlignment;
             static constexpr uint32 minSegmentSize = 32u * minChunkSize + sizeof(uint32);
             // Number of possible on page masks without taking the limit of 32 masks into account.
             static constexpr uint32 onPageMasks


### PR DESCRIPTION
After the changes of #220 the value of `minChunkSize` is generally not a power of 2. E.g. for 2 MB pages it was equal to 2047. For all allocations smaller than that, `ScatterAlloc` will allocate `minChunkSize` bytes instead in its `allocChunked()`.

I believe something is wrong there, and it causes #227. With the fix in this PR my previously failing PIConGPU setup now works. However, I am not sure what should the "alignment" be. Chose 16 as that was the value of `minChunkSize` before #220. @psychocoderHPC you probably know better what to use here.

We need to have this fix urgently, as it has to be ported to PIConGPU `dev` and release candidate branches.

Solves #227 .