### PR TITLE
fix wrong alignment

### DIFF
--- a/src/include/mallocMC/alignmentPolicies/Noop.hpp
+++ b/src/include/mallocMC/alignmentPolicies/Noop.hpp
@@ -53,7 +53,7 @@ namespace mallocMC
             }
 
             ALPAKA_FN_HOST_ACC
-            static auto applyPadding(size_t bytes) -> size_t
+            static auto applyPadding(uint32_t bytes) -> uint32_t
             {
                 return bytes;
             }

--- a/src/include/mallocMC/alignmentPolicies/Shrink.hpp
+++ b/src/include/mallocMC/alignmentPolicies/Shrink.hpp
@@ -130,9 +130,9 @@ namespace mallocMC
             }
 
             ALPAKA_FN_HOST_ACC
-            static auto applyPadding(size_t bytes) -> size_t
+            static auto applyPadding(uint32_t bytes) -> uint32_t
             {
-                constexpr auto bitsToClear = dataAlignment - 1;
+                constexpr uint32_t bitsToClear = dataAlignment - 1;
                 return (bytes + bitsToClear) & ~bitsToClear;
             }
 

--- a/src/include/mallocMC/creationPolicies/OldMalloc.hpp
+++ b/src/include/mallocMC/creationPolicies/OldMalloc.hpp
@@ -50,7 +50,7 @@ namespace mallocMC
         public:
             static constexpr auto providesAvailableSlots = false;
 
-            template<typename AlpakaAcc>
+            template<typename AlignmentPolicy, typename AlpakaAcc>
             ALPAKA_FN_ACC auto create(const AlpakaAcc& acc, uint32 bytes) const -> void*
             {
                 return ::malloc(static_cast<size_t>(bytes));

--- a/src/include/mallocMC/device_allocator.hpp
+++ b/src/include/mallocMC/device_allocator.hpp
@@ -67,7 +67,8 @@ namespace mallocMC
             ALPAKA_FN_ACC static auto getAvailableSlots(const AlpakaAcc& acc, size_t slotSize, T_Allocator& alloc)
                 -> unsigned
             {
-                return alloc.T_Allocator::CreationPolicy ::getAvailableSlotsAccelerator(acc, slotSize);
+                return alloc.T_Allocator::CreationPolicy::template getAvailableSlotsAccelerator<
+                    typename T_Allocator::AlignmentPolicy>(acc, slotSize);
             }
         };
 
@@ -110,7 +111,7 @@ namespace mallocMC
             bytes = AlignmentPolicy::applyPadding(bytes);
             DistributionPolicy distributionPolicy(acc);
             const uint32 req_size = distributionPolicy.collect(acc, bytes);
-            void* memBlock = CreationPolicy::create(acc, req_size);
+            void* memBlock = CreationPolicy::template create<AlignmentPolicy>(acc, req_size);
             if(CreationPolicy::isOOM(memBlock, req_size))
                 memBlock = OOMPolicy::handleOOM(memBlock);
             return distributionPolicy.distribute(acc, memBlock);


### PR DESCRIPTION
fix #227 and is a replacement for #228

In cases where the data allocation size is smaller than the minimum chunk size, the allocation size will be set to minimal chunk size.
In such cases, the alignment of the data can be wrong.

mallocMC inerface changes (not visible for the user):
- CreationPolicy::create() get the alignment policy as first template parameter
- AlignmentPolicy::applyPadding() requires 32bit input sizes and returns the size as 32bit value. (avoid cast operations)


Note: The changes will not increase the register-footprint (tested with PIConGPU)