### PR TITLE
fix examples

### DIFF
--- a/tests/dimensions.cpp
+++ b/tests/dimensions.cpp
@@ -34,7 +34,7 @@ using Idx = std::size_t;
 struct ScatterConfig
 {
     static constexpr auto pagesize = 4096;
-    static constexpr auto accessblocks = 8;
+    static constexpr auto accessblocksize = 8;
     static constexpr auto regionsize = 16;
     static constexpr auto wastefactor = 2;
     static constexpr auto resetfreedpages = false;

--- a/tests/policies.cpp
+++ b/tests/policies.cpp
@@ -36,7 +36,7 @@ using Acc = alpaka::AccGpuCudaRt<Dim, Idx>;
 struct ScatterConfig
 {
     static constexpr auto pagesize = 4096;
-    static constexpr auto accessblocks = 8;
+    static constexpr auto accessblocksize = 8;
     static constexpr auto regionsize = 16;
     static constexpr auto wastefactor = 2;
     static constexpr auto resetfreedpages = false;


### PR DESCRIPTION
Missed to apply the Scatter config name change `accessblocks` into
`accessblocksize` introduced in #225