### PR TITLE
Fix calculation of block size for scatter allocations

### DIFF
--- a/src/include/mallocMC/creationPolicies/Scatter.hpp
+++ b/src/include/mallocMC/creationPolicies/Scatter.hpp
@@ -937,6 +937,20 @@ namespace mallocMC
                 //  alignmentstatus); if(linid == 0) printf("c Heap Warning:
                 //  memory to use not 16 byte aligned...\n");
                 //}
+
+                // We have to calculate these values here, before using them for other things.
+                // First calculate how many blocks of the given size fit our memory pages in principle.
+                // However, we do not have to use the exact requested block size.
+                // So we redistribute actual memory between the chosen number of blocks
+                // and ensure that all blocks have the same number of regions.
+                const auto memorysize = static_cast<size_t>(numpages) * pagesize;
+                const auto numblocks = memorysize / accessblocksize;
+                const auto memoryperblock = memorysize / numblocks;
+                const auto pagesperblock = memoryperblock / pagesize;
+                const auto regionsperblock = pagesperblock / regionsize;
+                numregions = numblocks * regionsperblock;
+                numpages = numregions * regionsize;
+
                 PTE* ptes = (PTE*) (page + numpages);
                 uint32* regions = (uint32*) (ptes + numpages);
                 // sec check for mem size
@@ -950,6 +964,10 @@ namespace mallocMC
                         printf("c Heap Warning: needed to reduce number of "
                                "regions to stay within memory limit\n");
                 }
+                // Recalculate since numpages could have changed
+                ptes = (PTE*) (page + numpages);
+                regions = (uint32*) (ptes + numpages);
+
                 // if(linid == 0) printf("Heap info: wasting %d
                 // bytes\n",(((POINTEREQUIVALENT)memory) + memsize) -
                 // (POINTEREQUIVALENT)(regions + numregions));
@@ -972,7 +990,7 @@ namespace mallocMC
                 {
                     _memsize = memsize;
                     _numpages = numpages;
-                    _accessblocks = (static_cast<size_t>(numpages) * pagesize) / accessblocksize;
+                    _accessblocks = numblocks;
                     _ptes = (volatile PTE*) ptes;
                     _page = page;
                     _regions = regions;


### PR DESCRIPTION
Make sure all blocks have same number of full regions, and also fit the memory size. Details of what was wrong with it are desciribed in #236. Fixes #236.

Co-authored and co-investigated with @psychocoderHPC 