### PR TITLE
Fix potential signed int underflow in scatter alloc

### DIFF
--- a/src/include/mallocMC/creationPolicies/Scatter.hpp
+++ b/src/include/mallocMC/creationPolicies/Scatter.hpp
@@ -286,7 +286,7 @@ namespace mallocMC
             {
                 const uint32 low_part = (spot + 1) == sizeof(uint32) * CHAR_BIT ? 0u : (bitfield >> (spot + 1));
                 const uint32 high_part = (bitfield << (spots - (spot + 1)));
-                const uint32 selection_mask = spots == sizeof(uint32) * CHAR_BIT ? ~0 : ((1 << spots) - 1);
+                const uint32 selection_mask = spots == sizeof(uint32) * CHAR_BIT ? ~0 : ((1u << spots) - 1);
                 // wrap around the bitfields from the current spot to the left
                 bitfield = (high_part | low_part) & selection_mask;
                 // compute the step from the current spot in the bitfield
@@ -325,7 +325,7 @@ namespace mallocMC
                 uint32 spot = randInit() % spots;
                 for(;;)
                 {
-                    const uint32 mask = 1 << spot;
+                    const uint32 mask = 1u << spot;
                     const uint32 old = alpaka::atomicOp<alpaka::AtomicOr>(acc, bitfield, mask);
                     if((old & mask) == 0)
                         return spot;
@@ -397,7 +397,7 @@ namespace mallocMC
                 const uint32 segments = fullsegments + (additional_chunks > 0 ? 1 : 0);
                 uint32 spot = randInit() % segments;
                 const uint32 mask = _ptes[page].bitmask;
-                if((mask & (1 << spot)) != 0)
+                if((mask & (1u << spot)) != 0)
                     spot = nextspot(mask, spot, segments);
                 const uint32 tries = segments - popc(mask);
                 uint32* onpagemasks = onPageMasksPosition(page, segments);


### PR DESCRIPTION
Underflow technically happens in one of the changed lines: `(1 << 31) - 1` done in signed ints. [A small demo](https://godbolt.org/z/vYGj55nGo). However in reality it was probably optimized by a compiler to give a correct result.

The other two changed concern code that was already correct as it only involved `(1 << 31)` which is legal as explained [here](https://en.cppreference.com/w/cpp/language/operator_arithmetic) (in section on `Bitwise shift operators`). But just to make it more clearly correct.