### PR TITLE
Clarify calculation of block index in scatter alloc

### DIFF
--- a/src/include/mallocMC/creationPolicies/Scatter.hpp
+++ b/src/include/mallocMC/creationPolicies/Scatter.hpp
@@ -684,7 +684,8 @@ namespace mallocMC
                 {
                     const uint32 region = page / regionsize;
                     alpaka::atomicOp<alpaka::AtomicExch>(acc, (uint32*) (_regions + region), 0u);
-                    const uint32 block = region * regionsize * _accessblocks / _numpages;
+                    const uint32 pagesperblock = _numpages / _accessblocks;
+                    const uint32 block = page / pagesperblock;
                     if(warpid() + laneid() == 0)
                         alpaka::atomicOp<alpaka::AtomicMin>(acc, (uint32*) &_firstfreeblock, block);
                 }


### PR DESCRIPTION
The previous way was correct (taking into account #237 - before it was incorrect). However it was expressed in a somewhat confusing way, now express the same more directly.