### PR TITLE
Fit `accessblocksize` into heap for examples and tests

### DIFF
--- a/examples/mallocMC_example01.cpp
+++ b/examples/mallocMC_example01.cpp
@@ -43,7 +43,7 @@ using Acc = alpaka::ExampleDefaultAcc<Dim, Idx>;
 struct ScatterHeapConfig
 {
     static constexpr auto pagesize = 4096;
-    static constexpr auto accessblocksize = 2u * 1024u * 1024u * 1024u;
+    static constexpr auto accessblocksize = 512u * 1024u * 1024u;
     static constexpr auto regionsize = 16;
     static constexpr auto wastefactor = 2;
     static constexpr auto resetfreedpages = false;

--- a/examples/mallocMC_example03.cpp
+++ b/examples/mallocMC_example03.cpp
@@ -44,7 +44,7 @@ using Acc = alpaka::ExampleDefaultAcc<Dim, Idx>;
 struct ScatterConfig
 {
     static constexpr auto pagesize = 4096;
-    static constexpr auto accessblocksize = 2u * 1024u * 1024u * 1024u;
+    static constexpr auto accessblocksize = 512u * 1024u * 1024u;
     static constexpr auto regionsize = 16;
     static constexpr auto wastefactor = 2;
     static constexpr auto resetfreedpages = false;

--- a/tests/dimensions.cpp
+++ b/tests/dimensions.cpp
@@ -34,7 +34,7 @@ using Idx = std::size_t;
 struct ScatterConfig
 {
     static constexpr auto pagesize = 4096;
-    static constexpr auto accessblocksize = 2u * 1024u * 1024u * 1024u;
+    static constexpr auto accessblocksize = 256u * 1024u;
     static constexpr auto regionsize = 16;
     static constexpr auto wastefactor = 2;
     static constexpr auto resetfreedpages = false;

--- a/tests/policies.cpp
+++ b/tests/policies.cpp
@@ -36,7 +36,7 @@ using Acc = alpaka::AccGpuCudaRt<Dim, Idx>;
 struct ScatterConfig
 {
     static constexpr auto pagesize = 4096;
-    static constexpr auto accessblocksize = 8;
+    static constexpr auto accessblocksize = 256U * 1024U;
     static constexpr auto regionsize = 16;
     static constexpr auto wastefactor = 2;
     static constexpr auto resetfreedpages = false;


### PR DESCRIPTION
As realised by @psychocoderHPC, `accessblocksize` didn't fit into the total allocation size such that no pages were actually created. Now, examples are runnable again.