### PR TITLE
Make reservation policy owning

### DIFF
--- a/src/include/mallocMC/allocator.hpp
+++ b/src/include/mallocMC/allocator.hpp
@@ -166,7 +166,7 @@ namespace mallocMC
         ALPAKA_FN_HOST void free()
         {
             devAllocatorBuffer = {};
-            reservePolicy.resetMemPool(heapInfos.p);
+            reservePolicy.resetMemPool();
             heapInfos.size = 0;
             heapInfos.p = nullptr;
         }

--- a/src/include/mallocMC/reservePoolPolicies/AlpakaBuf.hpp
+++ b/src/include/mallocMC/reservePoolPolicies/AlpakaBuf.hpp
@@ -45,7 +45,7 @@ namespace mallocMC
                 return alpaka::getPtrNative(*poolBuffer);
             }
 
-            void resetMemPool(void* p)
+            void resetMemPool()
             {
                 poolBuffer = {};
             }

--- a/src/include/mallocMC/reservePoolPolicies/CudaSetLimits.hpp
+++ b/src/include/mallocMC/reservePoolPolicies/CudaSetLimits.hpp
@@ -63,7 +63,7 @@ namespace mallocMC
                 return nullptr;
             }
 
-            static void resetMemPool(void* p = nullptr)
+            static void resetMemPool()
             {
                 cudaDeviceSetLimit(cudaLimitMallocHeapSize, 8192U);
                 cudaGetLastError(); // cudaDeviceSetLimit() usually fails if any


### PR DESCRIPTION
Closes #244.

As discussed in #244, this makes the `ReservePoolPolicies` own the pool memory. We discussed that this might go beyond the scope of a "policy" but a renaming would break backwards compatibility, so should be well thought through. Tracked in #251.