### PR TITLE
Remove `no-commit-to-branch` from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ on: [push, pull_request]
 env:
   CPM_SOURCE_CACHE: ${{ github.workspace }}/cpm_modules
   CTEST_OUTPUT_ON_FAILURE: 1
+  SKIP: no-commit-to-branch
 jobs:
   pre-commit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Our CI currently fails in case of merge commits because they actually do commit to `main`.

Sorry, can't really test without merging anything.