### PR TITLE
Add default for scatter config

### DIFF
--- a/include/mallocMC/creationPolicies/Scatter.hpp
+++ b/include/mallocMC/creationPolicies/Scatter.hpp
@@ -1411,7 +1411,7 @@ namespace mallocMC
             }
         };
 
-        template<typename T, typename U = ScatterConf::DefaultScatterHashingParams>
+        template<typename T = ScatterConf::DefaultScatterConfig, typename U = ScatterConf::DefaultScatterHashingParams>
         struct Scatter
         {
             template<typename V>


### PR DESCRIPTION
Has been there in the original implementation and I forgot to copy that to the new interface.