### PR TITLE
Fix array assert compilation failure

### DIFF
--- a/examples/native-cuda/source/main.cu
+++ b/examples/native-cuda/source/main.cu
@@ -26,12 +26,13 @@
   THE SOFTWARE.
 */
 
+#include "mallocMC/span.hpp"
+
 #include <mallocMC/mallocMC.cuh>
 
 #include <cstdint>
 #include <cstdlib>
 #include <functional>
-#include <span>
 
 /**
  * @brief Computes the sum of squares of the first `n` natural numbers.
@@ -66,15 +67,14 @@ __device__ auto sumOfSquares(auto const n)
  */
 __global__ void oneDotProductPerThread(mallocMC::CudaMemoryManager<> memoryManager, uint64_t numValues)
 {
+    using mallocMC::span;
     uint64_t tid = threadIdx.x + blockIdx.x * blockDim.x;
 
     // Not very realistic, all threads are doing this on their own:
-    auto a = std::span<uint64_t>(
-        reinterpret_cast<uint64_t*>(memoryManager.malloc(numValues * sizeof(uint64_t))),
-        numValues);
-    auto b = std::span<uint64_t>(
-        reinterpret_cast<uint64_t*>(memoryManager.malloc(numValues * sizeof(uint64_t))),
-        numValues);
+    auto a
+        = span<uint64_t>(reinterpret_cast<uint64_t*>(memoryManager.malloc(numValues * sizeof(uint64_t))), numValues);
+    auto b
+        = span<uint64_t>(reinterpret_cast<uint64_t*>(memoryManager.malloc(numValues * sizeof(uint64_t))), numValues);
 
     std::iota(std::begin(a), std::end(a), tid);
     std::iota(std::begin(b), std::end(b), tid);

--- a/include/mallocMC/creationPolicies/FlatterScatter/BitField.hpp
+++ b/include/mallocMC/creationPolicies/FlatterScatter/BitField.hpp
@@ -28,6 +28,7 @@
 
 #include "mallocMC/creationPolicies/FlatterScatter/wrappingLoop.hpp"
 #include "mallocMC/mallocMC_utils.hpp"
+#include "mallocMC/span.hpp"
 
 #include <alpaka/core/Common.hpp>
 #include <alpaka/intrinsic/Traits.hpp>
@@ -36,7 +37,6 @@
 
 #include <cstdint>
 #include <limits>
-#include <span>
 #include <type_traits>
 
 namespace mallocMC::CreationPolicies::FlatterScatterAlloc
@@ -344,7 +344,7 @@ namespace mallocMC::CreationPolicies::FlatterScatterAlloc
     template<uint32_t MyBitMaskSize = BitMaskSize>
     struct BitFieldFlatImpl
     {
-        std::span<BitMaskImpl<MyBitMaskSize>> data;
+        mallocMC::span<BitMaskImpl<MyBitMaskSize>> data;
 
         /**
          * @brief Check if the index-th bit in the bit field is set (=1).

--- a/include/mallocMC/span.hpp
+++ b/include/mallocMC/span.hpp
@@ -1,0 +1,86 @@
+/*
+  mallocMC: Memory Allocator for Many Core Architectures.
+  http://www.icg.tugraz.at/project/mvp
+  https://www.hzdr.de/crp
+
+  Copyright (C) 2012 Institute for Computer Graphics and Vision,
+                     Graz University of Technology
+  Copyright (C) 2014-2026 Institute of Radiation Physics,
+                     Helmholtz-Zentrum Dresden - Rossendorf
+
+  Author(s):  Markus Steinberger - steinberger ( at ) icg.tugraz.at
+              Bernhard Kainz - kainz ( at ) icg.tugraz.at
+              Michael Kenzel - kenzel ( at ) icg.tugraz.at
+              Rene Widera - r.widera ( at ) hzdr.de
+              Axel Huebl - a.huebl ( at ) hzdr.de
+              Carlchristian Eckert - c.eckert ( at ) hzdr.de
+              Julian Lenz - j.lenz ( at ) hzdr.de
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+*/
+
+// This is a workaround for the following issue:
+// https://github.com/llvm/llvm-project/pull/136133
+// If clang or clang-based compilers like hipcc try to compile device code
+// with a too recent version of libstdc++ from GCC,
+// they run into issues like
+// error: reference to __host__ function '__glibcxx_assert_fail' in __host__ __device__ function
+
+#pragma once
+#include <cstddef>
+
+namespace mallocMC
+{
+    template<typename TData>
+    struct span
+    {
+        TData* ptr_;
+        size_t size_;
+
+        constexpr span(TData* ptr, size_t size) : ptr_(ptr), size_(size) {};
+
+        // This is explicitly NOT `explcit` because we want to be able to
+        // silently wrap an array into a span within other constructor calls.
+        template<size_t N>
+        constexpr span(TData (&arr)[N]) : ptr_(arr)
+                                        , size_(N)
+        {
+        }
+
+        [[nodiscard]] constexpr auto size() const -> size_t
+        {
+            return size_;
+        }
+
+        [[nodiscard]] constexpr auto operator[](size_t index) const -> decltype(auto)
+        {
+            return ptr_[index];
+        }
+
+        [[nodiscard]] constexpr auto begin() const -> decltype(auto)
+        {
+            return ptr_;
+        }
+
+        [[nodiscard]] constexpr auto end() const -> decltype(auto)
+        {
+            return &(ptr_[size_]);
+        }
+    };
+} // namespace mallocMC

--- a/test/unit/source/AccessBlock.cpp
+++ b/test/unit/source/AccessBlock.cpp
@@ -29,6 +29,7 @@
 #include "mallocMC/creationPolicies/FlatterScatter/BitField.hpp"
 #include "mallocMC/creationPolicies/FlatterScatter/PageInterpretation.hpp"
 #include "mallocMC/mallocMC_utils.hpp"
+#include "mallocMC/span.hpp"
 #include "mocks.hpp"
 
 #include <alpaka/acc/AccCpuSerial.hpp>
@@ -53,6 +54,8 @@
 #include <limits>
 #include <stdexcept>
 #include <type_traits>
+
+using mallocMC::span;
 
 template<typename T_HeapConfig, typename T_AlignmentPolicy>
 struct TestableAccessBlock
@@ -608,7 +611,7 @@ TEST_CASE("AccessBlock (Regression)")
         // Fill all memory with ones.
         for(void* pointer : pointers)
         {
-            auto mem = std::span(static_cast<unsigned char*>(pointer), chunkSizeOneMask);
+            auto mem = span(static_cast<unsigned char*>(pointer), chunkSizeOneMask);
             for(auto& byte : mem)
             {
                 byte = std::numeric_limits<unsigned char>::max();
@@ -621,7 +624,7 @@ TEST_CASE("AccessBlock (Regression)")
         accessBlock.destroy(accSerial, freedPointer);
 
         void* pointerTwoMasks = accessBlock.create(accSerial, chunkSizeTwoMasks);
-        for(auto& c : std::span(static_cast<unsigned char*>(pointerTwoMasks), chunkSizeTwoMasks))
+        for(auto& c : span(static_cast<unsigned char*>(pointerTwoMasks), chunkSizeTwoMasks))
         {
             c = 0U;
         }
@@ -631,7 +634,7 @@ TEST_CASE("AccessBlock (Regression)")
         {
             if(pointer != freedPointer)
             {
-                auto mem = std::span(static_cast<unsigned char*>(pointer), chunkSizeOneMask);
+                auto mem = span(static_cast<unsigned char*>(pointer), chunkSizeOneMask);
                 CHECK(std::all_of(
                     mem.begin(),
                     mem.end(),
@@ -640,7 +643,7 @@ TEST_CASE("AccessBlock (Regression)")
             }
         }
 
-        auto mem = std::span(static_cast<unsigned char*>(pointerTwoMasks), chunkSizeTwoMasks);
+        auto mem = span(static_cast<unsigned char*>(pointerTwoMasks), chunkSizeTwoMasks);
         CHECK(std::all_of(mem.begin(), mem.end(), [](auto const val) { return val == 0U; }));
 
         // Now, we want to be really explicit:

--- a/test/unit/source/BitField.cpp
+++ b/test/unit/source/BitField.cpp
@@ -25,6 +25,7 @@
 */
 
 #include "mallocMC/mallocMC_utils.hpp"
+#include "mallocMC/span.hpp"
 #include "mocks.hpp"
 
 #include <alpaka/acc/AccCpuSerial.hpp>
@@ -40,6 +41,7 @@
 
 using mallocMC::CreationPolicies::FlatterScatterAlloc::BitFieldFlatImpl;
 using mallocMC::CreationPolicies::FlatterScatterAlloc::BitMaskImpl;
+using mallocMC::span;
 
 using BitMaskSizes = std::tuple<
     std::integral_constant<uint32_t, 16U>, // NOLINT(*magic-number*)
@@ -157,7 +159,7 @@ TEMPLATE_LIST_TEST_CASE("BitFieldFlat", "", BitMaskSizes)
     SECTION("knows a free bit if later ones are free, too.")
     {
         uint32_t const index = GENERATE(0, 1, numChunks / 2, numChunks - 1);
-        for(auto& mask : std::span{static_cast<BitMask*>(data), index / BitMaskSize})
+        for(auto& mask : span{static_cast<BitMask*>(data), index / BitMaskSize})
         {
             mask.set(accSerial);
         }
@@ -174,7 +176,7 @@ TEMPLATE_LIST_TEST_CASE("BitFieldFlat", "", BitMaskSizes)
     SECTION("knows its first free bit for different numChunks.")
     {
         auto localNumChunks = numChunks / GENERATE(1, 2, 3);
-        std::span localData{static_cast<BitMask*>(data), mallocMC::ceilingDivision(localNumChunks, BitMaskSize)};
+        span localData{static_cast<BitMask*>(data), mallocMC::ceilingDivision(localNumChunks, BitMaskSize)};
         uint32_t const index = GENERATE(0, 1, 10, 12);
         for(auto& mask : localData)
         {


### PR DESCRIPTION
There's an unfortunate compiler compilation that fails to build some standard library code:
- Modern GCC >= 15 has some memory hardening that performs bounds-checking via non-constexpr asserts for spans and arrays.
- Clang device compilation relies on the standard library being constexpr for device support of the standard library.

Thus, if you try to compile standard library code for device, you might hit those asserts being non-constexpr host-only functions. LLVM >= 21.8.0 has a [workaround for this](https://github.com/llvm/llvm-project/pull/136133) (see there for details, examples, etc.) but the ROCm 6.x.x stack builds on a much older LLVM version.

This PR replaces standard library `span` with an own constexpr-only implementation of the necessary functionality.