### PR TITLE
Make numPages host device

### DIFF
--- a/include/mallocMC/creationPolicies/FlatterScatter/AccessBlock.hpp
+++ b/include/mallocMC/creationPolicies/FlatterScatter/AccessBlock.hpp
@@ -147,7 +147,7 @@ namespace mallocMC::CreationPolicies::FlatterScatterAlloc
          *
          * @return The number of pages in the access block.
          */
-        ALPAKA_FN_INLINE ALPAKA_FN_ACC constexpr static auto numPages() -> uint32_t
+        ALPAKA_FN_INLINE ALPAKA_FN_HOST_ACC constexpr static auto numPages() -> uint32_t
         {
             constexpr auto numberOfPages = blockSize / (pageSize + sizeof(PageTable<1>));
             // check that the page table entries does not have a padding


### PR DESCRIPTION
```
/__w/spearhed/spearhed/thirdParty/picongpu/thirdParty/mallocMC/include/mallocMC/creationPolicies/FlatterScatter.hpp:420:60: error: reference to __device__ function 'numPages' in __host__ function
  420 |             auto numPagesPerBlock = MyHeap::MyAccessBlock::numPages();
      |                                                            ^
/__w/spearhed/spearhed/thirdParty/picongpu/thirdParty/mallocMC/include/mallocMC/allocator.hpp:148:38: note: called by 'alloc<alpaka::DevUniformCudaHipRt<alpaka::ApiCudaRt>, alpaka::uniform_cuda_hip::detail::QueueUniformCudaHipRt<alpaka::ApiCudaRt, false>>'
  148 |             CreationPolicy::template initHeap<AlpakaAcc>(
      |                                      ^
/__w/spearhed/spearhed/thirdParty/picongpu/thirdParty/mallocMC/include/mallocMC/allocator.hpp:197:13: note: called by 'destructiveResize<alpaka::DevUniformCudaHipRt<alpaka::ApiCudaRt>, alpaka::uniform_cuda_hip::detail::QueueUniformCudaHipRt<alpaka::ApiCudaRt, false>>'
  197 |             alloc(dev, queue, size);
      |             ^
/__w/spearhed/spearhed/include/spearhed/control/Simulation.x.cpp:219:21: note: called by 'init'
  219 |         deviceHeap->destructiveResize(alpakaDevice, alpakaQueue, small_heap);
```
I run into the error when using clang as the CUDA compiler.