### PR TITLE
Remove user defined constructor from AllocatorHandleImpl

### DIFF
--- a/include/mallocMC/mallocMC_allocator_handle.hpp
+++ b/include/mallocMC/mallocMC_allocator_handle.hpp
@@ -39,10 +39,6 @@ namespace mallocMC
 
         DevAllocator* devAllocator;
 
-        explicit AllocatorHandleImpl(DevAllocator* p) : devAllocator(p)
-        {
-        }
-
         template<typename AlpakaAcc>
         ALPAKA_FN_ACC auto malloc(AlpakaAcc const& acc, size_t size) const -> void*
         {


### PR DESCRIPTION
So this was a fun one. Really ended up getting to the point of a `printf` before and after every function call and being totally puzzled why execution just stops in the middle silently. 

I had this piece of code,
``` c++ 
    static constexpr int allocationMaxRetries = 13;

    // Raw allocation and retry logic using mallocMC
    [[nodiscard]] constexpr void* allocateRawMemory(
        auto const& worker,
        auto deviceHeapHandle,
        size_t size,
        std::align_val_t alignment)
    {
        for(int i = 0; i < allocationMaxRetries; ++i)
        {
            void* rawPtr = nullptr;
#if (BOOST_LANG_CUDA || BOOST_COMP_HIP)
            rawPtr = deviceHeapHandle.malloc(worker.getAcc(), size);
#else
            // Use nothrow to ensure nullptr is returned on failure,
            // preventing exceptions from breaking the retry loop.
            rawPtr = operator new(size, alignment, std::nothrow);
#endif
            if(rawPtr != nullptr)
            {
                return rawPtr;
            }
        }
        return nullptr;
    }

    // Allocates memory unintialized
    template<typename T>
    [[nodiscard]] constexpr T* allocateMemory(auto const& worker, auto deviceHeapHandle)
    {
        void* mem = allocateRawMemory(worker, deviceHeapHandle, sizeof(T), std::align_val_t{alignof(T)});
        if(mem)
        {
            return static_cast<T*>(mem);
        }
        return nullptr;
    }

``` 
It was called by one thread in a block as below 
``` c++
printf("a\n");
PtrType tmp = memory::allocateMemory<T>(worker, m_deviceHeapHandle);
printf("b\n");
```
This pointer was then stored in shared memory. And then later all threads used this pointer to access the allocated memory. What i saw was that I get segfaults.
Eventually with the `printf`s I noted that the main thread doing the allocation prints `a` but not `b`. 
So my main thread execution was failing silently.
Switching `allocateMemory` and `allocateRawMemory` to accept the heap handle by reference solved the issue.

I guess what happens is the (implicitly defined) copy constructor of the heap handle is not marked as device. And this was crashing my main thread execution silently.
Removing the host only constructor fixes my issue and lets me pass by value.
Marking the constructor as constexpr also has the same effect. I guess because then the compiler generated copy constructor is also constexpr.

I decided just removing the user defined constructor is cleanest, but if you prefer you can opt for marking it as constexpr/host device as well.