### PR TITLE
fix using __AMDGCN_WAVEFRONT_SIZE

### DIFF
--- a/include/mallocMC/creationPolicies/FlatterScatter.hpp
+++ b/include/mallocMC/creationPolicies/FlatterScatter.hpp
@@ -312,7 +312,7 @@ namespace mallocMC::CreationPolicies::FlatterScatterAlloc
         template<uint32_t T_pageSize, typename TAcc>
         ALPAKA_FN_INLINE ALPAKA_FN_ACC static auto hash(TAcc const& acc, uint32_t const numBytes) -> uint32_t
         {
-            uint32_t const relative_offset = warpSize<TAcc> * numBytes / T_pageSize;
+            uint32_t const relative_offset = getWarpSize<TAcc>() * numBytes / T_pageSize;
             return (
                 numBytes * hashingK + hashingDistMP * smid(acc)
                 + (hashingDistWP + hashingDistWPRel * relative_offset) * warpid(acc));

--- a/include/mallocMC/creationPolicies/Scatter.hpp
+++ b/include/mallocMC/creationPolicies/Scatter.hpp
@@ -559,7 +559,7 @@ namespace mallocMC
                 uint32 const minAllocation = alpaka::math::max(acc, bytes, paddedMinChunkSize);
                 uint32 const numpages = _numpages;
                 uint32 const pagesperblock = numpages / _accessblocks;
-                uint32 const reloff = warpSize<AlpakaAcc> * minAllocation / pagesize;
+                uint32 const reloff = getWarpSize<AlpakaAcc>() * minAllocation / pagesize;
                 uint32 const start_page_in_block = (minAllocation * hashingK + hashingDistMP * smid(acc)
                                                     + (hashingDistWP + hashingDistWPRel * reloff) * warpid(acc))
                                                    % pagesperblock;
@@ -653,7 +653,6 @@ namespace mallocMC
                             if(access_block_id > _firstfreeblock)
                                 _firstfreeblock = access_block_id;
                         }
-
                     } while(global_page != global_start_page);
 
                     // we are really full :/ so lets search every page for a segment!
@@ -910,9 +909,11 @@ namespace mallocMC
                 void* res = 0;
                 // based on the alpaka backend the lanemask type can be 64bit
                 auto const mask = alpaka::warp::activemask(acc);
+                // required else popcount() will be ambigious
+                using MaskType = decltype(mask);
                 uint32_t const num = alpaka::popcount(acc, mask);
                 // based on the alpaka backend the lanemask type can be 64bit
-                auto const lanemask = lanemask_lt(acc);
+                MaskType const lanemask = lanemask_lt(acc);
                 uint32_t const local_id = alpaka::popcount(acc, lanemask & mask);
                 for(unsigned int active = 0; active < num; ++active)
                     if(active == local_id)
@@ -1348,46 +1349,41 @@ namespace mallocMC
              * expected if every thread in the warp executes the function. Uses
              * 256 byte of shared memory.
              *
+             * @attention: This is a collective function and must be called by all threads in the thread block.
+             *
              * @param slotSize the size of allocatable elements to count
              */
             template<typename AlpakaAcc>
             ALPAKA_FN_ACC auto getAvailableSlotsAccelerator(AlpakaAcc const& acc, size_t slotSize) -> unsigned
             {
-                int const wId = warpid_withinblock(acc); // do not use warpid-function, since
-                                                         // this value is not guaranteed to
-                                                         // be stable across warp lifetime
+                if(slotSize == 0)
+                    return 0;
 
-                uint32 const activeThreads = alpaka::popcount(acc, alpaka::warp::activemask(acc));
+                auto& sharedResult = alpaka::declareSharedVar<std::uint32_t, __COUNTER__>(acc);
 
-                constexpr auto warpsize = warpSize<AlpakaAcc>;
-                auto& activePerWarp = alpaka::declareSharedVar<
-                    std::uint32_t[maxThreadsPerBlock / warpsize],
-                    __COUNTER__>(acc); // maximum number of warps in a block
+                auto const localThreadIdx = alpaka::getIdx<alpaka::Block, alpaka::Threads>(acc);
+                auto const localThreadExtent = alpaka::getWorkDiv<alpaka::Block, alpaka::Threads>(acc);
+                uint32_t const linearizedLocalThreadIdx
+                    = static_cast<std::uint32_t>(alpaka::mapIdx<1u>(localThreadIdx, localThreadExtent)[0]);
 
-                auto& warpResults
-                    = alpaka::declareSharedVar<unsigned[maxThreadsPerBlock / warpSize<AlpakaAcc>], __COUNTER__>(acc);
-
-                warpResults[wId] = 0;
-                activePerWarp[wId] = 0;
+                if(linearizedLocalThreadIdx == 0u)
+                    sharedResult = 0u;
 
                 // wait that all shared memory is initialized
                 alpaka::syncBlockThreads(acc);
 
-                // the active threads obtain an id from 0 to activeThreads-1
-                if(slotSize == 0)
-                    return 0;
-                auto const linearId = alpaka::atomicOp<alpaka::AtomicAdd>(acc, &activePerWarp[wId], 1u);
-
-                // printf("Block %d, id %d: activeThreads=%d
-                // linearId=%d\n",blockIdx.x,threadIdx.x,activeThreads,linearId);
-                unsigned const temp = this->getAvailaibleSlotsDeviceFunction(acc, slotSize, linearId, activeThreads);
-                if(temp)
-                    alpaka::atomicOp<alpaka::AtomicAdd>(acc, &warpResults[wId], temp);
+                uint32_t numThreadsInBlock = static_cast<std::uint32_t>(localThreadExtent.prod());
+                unsigned const temp = this->getAvailaibleSlotsDeviceFunction(
+                    acc,
+                    slotSize,
+                    linearizedLocalThreadIdx,
+                    numThreadsInBlock);
+                alpaka::atomicOp<alpaka::AtomicAdd>(acc, &sharedResult, temp);
 
                 alpaka::syncBlockThreads(acc);
                 alpaka::mem_fence(acc, alpaka::memory_scope::Block{});
 
-                return warpResults[wId];
+                return sharedResult;
             }
 
             static auto classname() -> std::string

--- a/include/mallocMC/device_allocator.hpp
+++ b/include/mallocMC/device_allocator.hpp
@@ -96,6 +96,8 @@ namespace mallocMC
 
         /** Provide the number of available free slots.
          *
+         * @attention: This is a collective function and must be called by all threads in the thread block.
+         *
          * @tparam AlpakaAcc The type of the Allocator to be used
          * @param acc alpaka accelerator
          * @param slotSize assumed allocation size in bytes

--- a/include/mallocMC/distributionPolicies/XMallocSIMD.hpp
+++ b/include/mallocMC/distributionPolicies/XMallocSIMD.hpp
@@ -126,9 +126,8 @@ namespace mallocMC
                 threadcount = 0;
 
                 // init with initial counter
-                auto& warp_sizecounter
-                    = alpaka::declareSharedVar<std::uint32_t[maxThreadsPerBlock / warpSize<AlpakaAcc>()], __COUNTER__>(
-                        acc);
+                auto& warp_sizecounter = alpaka::
+                    declareSharedVar<std::uint32_t[maxThreadsPerBlock / getWarpSize<AlpakaAcc>()], __COUNTER__>(acc);
                 warp_sizecounter[warpid] = 16;
 
                 // second half: make sure that all coalesced allocations can fit
@@ -157,7 +156,8 @@ namespace mallocMC
             ALPAKA_FN_ACC auto distribute(AlpakaAcc const& acc, void* allocatedMem) -> void*
             {
                 auto& warp_res
-                    = alpaka::declareSharedVar<char * [maxThreadsPerBlock / warpSize<AlpakaAcc>()], __COUNTER__>(acc);
+                    = alpaka::declareSharedVar<char * [maxThreadsPerBlock / getWarpSize<AlpakaAcc>()], __COUNTER__>(
+                        acc);
 
                 char* myalloc = (char*) allocatedMem;
                 if(req_size && can_use_coalescing)

--- a/include/mallocMC/mallocMC_utils.hpp
+++ b/include/mallocMC/mallocMC_utils.hpp
@@ -57,23 +57,18 @@
 namespace mallocMC
 {
 
+    /** Get the number of threads in a warp.
+     *
+     * @attention If alpaka does not know the compile time warp size zero will be returned.
+     *
+     * @return number of threads in a warp, for unknown devices it will return zero.
+     */
     template<typename TAcc>
-    constexpr uint32_t warpSize = 1U;
-
-#ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
-    template<typename TDim, typename TIdx>
-    constexpr uint32_t warpSize<alpaka::AccGpuCudaRt<TDim, TIdx>> = 32U;
-#endif
-
-#ifdef ALPAKA_ACC_GPU_HIP_ENABLED
-#    if (HIP_VERSION_MAJOR >= 4)
-    template<typename TDim, typename TIdx>
-    constexpr uint32_t warpSize<alpaka::AccGpuHipRt<TDim, TIdx>> = __AMDGCN_WAVEFRONT_SIZE;
-#    else
-    template<typename TDim, typename TIdx>
-    constexpr uint32_t warpSize<alpaka::AccGpuHipRt<TDim, TIdx>> = 64;
-#    endif
-#endif
+    consteval uint32_t getWarpSize()
+    {
+        constexpr auto warpSize = alpaka::warp::getSizeCompileTime<TAcc>();
+        return warpSize;
+    }
 
     ALPAKA_FN_ACC inline auto laneid()
     {
@@ -190,7 +185,7 @@ namespace mallocMC
         auto const localId = alpaka::mapIdx<1>(
             alpaka::getIdx<alpaka::Block, alpaka::Threads>(acc),
             alpaka::getWorkDiv<alpaka::Block, alpaka::Threads>(acc))[0];
-        return localId / warpSize<AlpakaAcc>;
+        return localId / getWarpSize<AlpakaAcc>();
     }
 
     template<typename T, typename U, typename = std::enable_if_t<std::is_integral_v<T> && std::is_integral_v<U>>>


### PR DESCRIPTION
fix https://github.com/alpaka-group/mallocMC/issues/299

- Refactor the code to use alpaka's warp size function
- fix bug that `Scatter::getAvailableSlotsAccelerator()` was not
  mentioning the requirement to be called as a collective method.

- [x] merge #306 first (first 2 commits)